### PR TITLE
feat: enhance AudioPool with instance count management

### DIFF
--- a/src/utils/indexed-db.ts
+++ b/src/utils/indexed-db.ts
@@ -1,6 +1,6 @@
 const DB_NAME = 'soundboard_cache';
 const STORE_NAME = 'audio_files';
-const DB_VERSION = 1;
+const DB_VERSION = 2;
 
 export class AudioDB {
     private db: IDBDatabase | null = null;
@@ -17,9 +17,19 @@ export class AudioDB {
 
             request.onupgradeneeded = (event) => {
                 const db = (event.target as IDBOpenDBRequest).result;
-                if (!db.objectStoreNames.contains(STORE_NAME)) {
+                const oldVersion = event.oldVersion;
+
+                if (oldVersion < 1) {
                     const store = db.createObjectStore(STORE_NAME, { keyPath: 'url' });
                     store.createIndex('timestamp', 'timestamp', { unique: false });
+                }
+
+                if (oldVersion < 2) {
+                    const store = request.transaction!.objectStore(STORE_NAME);
+                    
+                    if (!store.indexNames.contains('timestamp')) {
+                        store.createIndex('timestamp', 'timestamp', { unique: false });
+                    }
                 }
             };
         });

--- a/src/utils/indexed-db.ts
+++ b/src/utils/indexed-db.ts
@@ -17,7 +17,7 @@ export class AudioDB {
 
             request.onupgradeneeded = (event) => {
                 const db = (event.target as IDBOpenDBRequest).result;
-                const oldVersion = event.oldVersion;
+                const {oldVersion} = event;
 
                 if (oldVersion < 1) {
                     const store = db.createObjectStore(STORE_NAME, { keyPath: 'url' });


### PR DESCRIPTION
This pull request includes several changes to the `AudioPool` class and the `AudioDB` class to enhance audio management and improve database handling. The most important changes include adding instance count tracking for audio sources, modifying the constructor to accept a maximum instances per sound parameter, and updating the IndexedDB version to handle new schema changes.

Enhancements to `AudioPool` class:

* Added `maxInstancesPerSound` and `instanceCounts` properties to the `AudioPool` class and updated the constructor to accept `maxInstancesPerSound` as a parameter.
* Implemented logic to decrement the instance count when an audio element ends or encounters an error. [[1]](diffhunk://#diff-36f45de6cbaa09295d2e80ff6b6e35cccf7783db6aa28cfa78ee63a0333e5308R67-R72) [[2]](diffhunk://#diff-36f45de6cbaa09295d2e80ff6b6e35cccf7783db6aa28cfa78ee63a0333e5308R86-R91)
* Modified `playFromUrl` method to handle maximum instances per sound and clean up the oldest instance if the limit is reached.
* Updated the `playFromUrl` method to increment the instance count when an audio element starts playing.
* Added logic to clear `instanceCounts` when the pool is cleared and to delete the instance count for a specific source when it is stopped. [[1]](diffhunk://#diff-36f45de6cbaa09295d2e80ff6b6e35cccf7783db6aa28cfa78ee63a0333e5308R222) [[2]](diffhunk://#diff-36f45de6cbaa09295d2e80ff6b6e35cccf7783db6aa28cfa78ee63a0333e5308R232)

Updates to `AudioDB` class:

* Incremented the `DB_VERSION` to 2 and added logic to handle schema upgrades, including adding a new index if it does not exist. [[1]](diffhunk://#diff-c47d3c63118882a412d9017a9803c6e00e71438049b4b0d0bb183a176bc5ae12L3-R3) [[2]](diffhunk://#diff-c47d3c63118882a412d9017a9803c6e00e71438049b4b0d0bb183a176bc5ae12L20-R33)

## Summary by Sourcery

Enhance audio management in AudioPool by adding instance count tracking and improving database handling in AudioDB

New Features:
- Add instance count management for audio sources in AudioPool
- Implement maximum instances per sound limit

Bug Fixes:
- Ensure proper cleanup of audio instances when they end or encounter errors

Enhancements:
- Modify AudioPool constructor to support maximum instances per sound
- Update audio playback logic to handle instance count tracking
- Improve audio source management by cleaning up oldest instances when limit is reached

Chores:
- Increment IndexedDB version to support schema upgrades