### PR TITLE
docs: add macOS build script to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ npm install
 - `npm run dev` - Starts the app in development mode with hot reload
 - `npm run build` - Builds the application
 - `npm run build:win` - Creates a portable Windows executable
+- `npm run build:mac` - Creates a portable Mac executable
 
 ### Development Scripts
 
@@ -72,10 +73,6 @@ To create a portable Macbook executable:
 ```bash
 npm run build:mac
 ```
-
----
-
-Let me know if you'd like me to rewrite it with more technical depth or keep it beginner-friendly.
 
 The built application will be available in the `release` directory.
 


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to add instructions for creating a portable Mac executable. The most important changes include adding a new script command and updating the documentation to reflect this addition.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R41): Added the `npm run build:mac` command to the list of available scripts for building the application.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-L79): Removed the redundant sentence and clarified the location of the built application for the Mac executable.