### PR TITLE
docs: update README for MacOS executable and clarify build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ npm install
 - `npm run dev` - Starts the app in development mode with hot reload
 - `npm run build` - Builds the application
 - `npm run build:win` - Creates a portable Windows executable
-- `npm run build:mac` - Creates a portable Mac executable
+- `npm run build:mac` - Creates a portable MacOS executable
 
 ### Development Scripts
 
@@ -68,7 +68,7 @@ To create a portable Windows executable:
 npm run build:win
 ```
 
-To create a portable Macbook executable:
+To create a portable MacOS executable:
 
 ```bash
 npm run build:mac

--- a/src/utils/audio-pool.ts
+++ b/src/utils/audio-pool.ts
@@ -147,7 +147,6 @@ class AudioPool {
                 }
             }
     } else if (!this.multiSoundEnabled) {
-            // When multiSound is disabled, stop all instances of this sound
             for (const [key, item] of this.pool.entries()) {
                 if (key.startsWith(source)) {
                     this.cleanupAudioItem(item);


### PR DESCRIPTION
This pull request includes changes to improve the clarity of documentation and clean up the codebase. The most important changes include updating terminology in the `README.md` file and removing an unnecessary comment from the `audio-pool.ts` file.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41): Changed references from "Mac" and "Macbook" to "MacOS" for consistency and clarity. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71-R71)

Codebase cleanup:

* [`src/utils/audio-pool.ts`](diffhunk://#diff-36f45de6cbaa09295d2e80ff6b6e35cccf7783db6aa28cfa78ee63a0333e5308L150): Removed an unnecessary comment in the `AudioPool` class to improve code readability.

## Summary by Sourcery

Update documentation and clean up codebase by improving terminology and removing unnecessary comments

Enhancements:
- Remove unnecessary comment in audio-pool.ts to improve code readability

Documentation:
- Update README to use consistent 'MacOS' terminology instead of 'Mac' and 'Macbook' in build instructions