### PR TITLE
chore: update version to 2.1.4 and enable isolated modules in tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soundboard",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soundboard",
-      "version": "2.1.3",
+      "version": "2.1.4",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soundboard",
-  "version": "2.1.3",
+  "version": "2.1.4",
   "description": "soundboard",
   "type": "module",
   "main": "dist/main.cjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "isolatedModules": false,
+    "isolatedModules": true,
     "outDir": "./dist",
     "rootDir": ".",
     "baseUrl": ".",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file. The change updates the version number from `2.1.3` to `2.1.4`.